### PR TITLE
fix security groups key

### DIFF
--- a/lib/ex_aws/ec2.ex
+++ b/lib/ex_aws/ec2.ex
@@ -366,8 +366,8 @@ defmodule ExAws.EC2 do
     placement: placement,
     private_ip_address: binary,
     ramdisk_id: binary,
-    security_groups: [binary, ...],
-    security_group_ids: [binary, ...],
+    security_group: [binary, ...],
+    security_group_id: [binary, ...],
     subnet_id: binary,
     tag_specifications: [tag_specification, ...],
     user_data: binary


### PR DESCRIPTION
security_group_ids is incorrect key. Using this you will get error:

"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Response><Errors><Error><Code>UnknownParameter</Code><Message>The parameter SecurityGroupIds is not recognized</Message></Error></Errors><RequestID>ed9b4ed5-93c2-4907-ac67-0a3349368f49</RequestID></Response>"